### PR TITLE
JDK upgrade to address CVEs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,9 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//builders/bazel:deps.bzl", "python_deps", "python_register_toolchains")
+load("//third_party:jdk_override.bzl", "jdk_21_override")
+
+# JDK 21.48.15 CA override for Nessus CVE compliance (must be before default is loaded)
+jdk_21_override()
 
 # rules_docker v0.26.0 (Bazel 7+ compatible, cfg=host→exec fix)
 

--- a/docs/dependency-map.md
+++ b/docs/dependency-map.md
@@ -198,7 +198,7 @@ FINAL SERVICE DOCKER IMAGE (e.g., buyer_frontend_service_image.tar)
 │   ├── install/
 │   │   └── {bazel_version_hash}/          ← Bazel install base
 │   │       ├── A-server.jar               ← Bazel server
-│   │       └── embedded_tools/jdk/        ← ⚠ EMBEDDED JDK (version = Bazel version)
+│   │       └── embedded_tools/jdk/        ← EMBEDDED JDK (deleted post-build by build_and_test_all_in_docker for Nessus compliance)
 │   ├── cache/                             ← repo cache (shared downloads)
 │   └── {output_base_hash}/
 │       └── external/                      ← fetched WORKSPACE deps for sidecars
@@ -340,8 +340,8 @@ COUPLING ZONE 5: 4 Independent Workspaces ↔ Shared Cache
 | Dependency | Version/Ref | Defined In | Used By |
 |---|---|---|---|
 | Bazel | 7.4.1 | `.bazelversion` (×4) | All workspaces |
-| JDK (embedded) | 21.0.4 | Bazel 7.4.1 binary | Build process |
-| JDK (remote toolchain) | 21.0.3 | `.bazelrc` remotejdk_21 | Build process |
+| JDK (embedded) | 21.0.4 (Bazel 7.4.1) | Bazel install | Bazel server; removed post-build by build_and_test_all_in_docker for Nessus compliance |
+| JDK (remote toolchain) | 21.48.15 CA | `third_party/jdk_override.bzl` | Java compilation |
 | rules_docker | v0.26.0 | Root `WORKSPACE` | Main build only |
 | distroless base | cc-debian12 | `container_deps.bzl` | Runtime images |
 | Envoy sidecar | v1.31.4 | `container_deps.bzl` | Runtime images |

--- a/production/packaging/build_and_test_all_in_docker
+++ b/production/packaging/build_and_test_all_in_docker
@@ -25,6 +25,10 @@ trap _print_runtime EXIT
 function _print_runtime() {
   declare -r -i STATUS=$?
   declare -r END=$(date +%s)
+  # Remove embedded JDK from Bazel cache for Nessus compliance (only after all builds complete)
+  if [[ -d "${HOME}/.cache/bazel" ]]; then
+    find "${HOME}/.cache/bazel" -type d -path "*/install/*/embedded_tools/jdk" -exec rm -rf {} + 2>/dev/null || true
+  fi
   /usr/bin/env LC_ALL=en_US.UTF-8 printf "\nbuild_and_test_all_in_docker runtime: %'ds\n" $((END - START)) >/dev/stderr
   if [[ ${STATUS} -eq 0 ]]; then
     printf "build_and_test_in_docker completed successfully\n" &>/dev/stderr

--- a/services/inference_sidecar/common/.bazelrc
+++ b/services/inference_sidecar/common/.bazelrc
@@ -21,7 +21,7 @@ build --announce_rc
 build --verbose_failures
 build --config=clang
 build --compilation_mode=opt
-build --output_filter='^//((?!(third_party):).)*$'`
+build --output_filter='^//((?!(third_party):).)*$'
 build --color=yes
 
 build:clang --cxxopt=-fbracket-depth=512

--- a/services/inference_sidecar/common/WORKSPACE
+++ b/services/inference_sidecar/common/WORKSPACE
@@ -1,5 +1,9 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//builders/bazel:deps.bzl", "python_deps")
+load("//third_party:jdk_override.bzl", "jdk_21_override")
+
+# JDK 21.48.15 CA override for Nessus CVE compliance (must be before default is loaded)
+jdk_21_override()
 
 python_deps("//builders/bazel")
 

--- a/services/inference_sidecar/common/third_party/jdk_override.bzl
+++ b/services/inference_sidecar/common/third_party/jdk_override.bzl
@@ -1,0 +1,20 @@
+"""JDK 21.48.15 CA override for Nessus CVE compliance.
+
+Overrides default remotejdk21_linux with Azul Zulu 21.48.15 CA.
+Must be called before any rule that loads the default JDK.
+"""
+
+load("@bazel_tools//tools/jdk:remote_java_repository.bzl", "remote_java_repository")
+
+def jdk_21_override():
+    remote_java_repository(
+        name = "remotejdk21_linux",
+        version = "21",
+        target_compatible_with = ["@platforms//os:linux"],
+        prefix = "remotejdk",
+        urls = [
+            "https://cdn.azul.com/zulu/bin/zulu21.48.15-ca-jdk21.0.10-linux_x64.tar.gz",
+        ],
+        sha256 = "7f15f667580a8977962dc0a709cf2a097cc71244614fad3f236debce9d1c2670",
+        strip_prefix = "zulu21.48.15-ca-jdk21.0.10-linux_x64",
+    )

--- a/services/inference_sidecar/modules/pytorch_v2_1_1/.bazelrc
+++ b/services/inference_sidecar/modules/pytorch_v2_1_1/.bazelrc
@@ -21,7 +21,7 @@ build --announce_rc
 build --verbose_failures
 build --config=clang
 build --compilation_mode=opt
-build --output_filter='^//((?!(third_party):).)*$'`
+build --output_filter='^//((?!(third_party):).)*$'
 build --color=yes
 
 build:clang --cxxopt=-fbracket-depth=512

--- a/services/inference_sidecar/modules/pytorch_v2_1_1/WORKSPACE
+++ b/services/inference_sidecar/modules/pytorch_v2_1_1/WORKSPACE
@@ -1,4 +1,9 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//third_party:jdk_override.bzl", "jdk_21_override")
+
+# JDK 21.48.15 CA override for Nessus CVE compliance (must be before default is loaded)
+jdk_21_override()
+
 load("//third_party:pytorch_v2_1_1_deps1.bzl", "pytorch_v2_1_1_deps1")
 load("//third_party:pytorch_v2_1_1_deps2.bzl", "pytorch_v2_1_1_deps2")
 

--- a/services/inference_sidecar/modules/pytorch_v2_1_1/third_party/jdk_override.bzl
+++ b/services/inference_sidecar/modules/pytorch_v2_1_1/third_party/jdk_override.bzl
@@ -1,0 +1,20 @@
+"""JDK 21.48.15 CA override for Nessus CVE compliance.
+
+Overrides default remotejdk21_linux with Azul Zulu 21.48.15 CA.
+Must be called before any rule that loads the default JDK.
+"""
+
+load("@bazel_tools//tools/jdk:remote_java_repository.bzl", "remote_java_repository")
+
+def jdk_21_override():
+    remote_java_repository(
+        name = "remotejdk21_linux",
+        version = "21",
+        target_compatible_with = ["@platforms//os:linux"],
+        prefix = "remotejdk",
+        urls = [
+            "https://cdn.azul.com/zulu/bin/zulu21.48.15-ca-jdk21.0.10-linux_x64.tar.gz",
+        ],
+        sha256 = "7f15f667580a8977962dc0a709cf2a097cc71244614fad3f236debce9d1c2670",
+        strip_prefix = "zulu21.48.15-ca-jdk21.0.10-linux_x64",
+    )

--- a/services/inference_sidecar/modules/tensorflow_v2_14_0/WORKSPACE
+++ b/services/inference_sidecar/modules/tensorflow_v2_14_0/WORKSPACE
@@ -1,5 +1,9 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//builders/bazel:deps.bzl", "python_deps")
+load("//third_party:jdk_override.bzl", "jdk_21_override")
+
+# JDK 21.48.15 CA override for Nessus CVE compliance (must be before default is loaded)
+jdk_21_override()
 
 python_deps("//builders/bazel")
 

--- a/services/inference_sidecar/modules/tensorflow_v2_14_0/third_party/jdk_override.bzl
+++ b/services/inference_sidecar/modules/tensorflow_v2_14_0/third_party/jdk_override.bzl
@@ -1,0 +1,20 @@
+"""JDK 21.48.15 CA override for Nessus CVE compliance.
+
+Overrides default remotejdk21_linux with Azul Zulu 21.48.15 CA.
+Must be called before any rule that loads the default JDK.
+"""
+
+load("@bazel_tools//tools/jdk:remote_java_repository.bzl", "remote_java_repository")
+
+def jdk_21_override():
+    remote_java_repository(
+        name = "remotejdk21_linux",
+        version = "21",
+        target_compatible_with = ["@platforms//os:linux"],
+        prefix = "remotejdk",
+        urls = [
+            "https://cdn.azul.com/zulu/bin/zulu21.48.15-ca-jdk21.0.10-linux_x64.tar.gz",
+        ],
+        sha256 = "7f15f667580a8977962dc0a709cf2a097cc71244614fad3f236debce9d1c2670",
+        strip_prefix = "zulu21.48.15-ca-jdk21.0.10-linux_x64",
+    )

--- a/third_party/jdk_override.bzl
+++ b/third_party/jdk_override.bzl
@@ -1,0 +1,20 @@
+"""JDK 21.48.15 CA override for Nessus CVE compliance.
+
+Overrides default remotejdk21_linux with Azul Zulu 21.48.15 CA.
+Must be called before any rule that loads the default JDK.
+"""
+
+load("@bazel_tools//tools/jdk:remote_java_repository.bzl", "remote_java_repository")
+
+def jdk_21_override():
+    remote_java_repository(
+        name = "remotejdk21_linux",
+        version = "21",
+        target_compatible_with = ["@platforms//os:linux"],
+        prefix = "remotejdk",
+        urls = [
+            "https://cdn.azul.com/zulu/bin/zulu21.48.15-ca-jdk21.0.10-linux_x64.tar.gz",
+        ],
+        sha256 = "7f15f667580a8977962dc0a709cf2a097cc71244614fad3f236debce9d1c2670",
+        strip_prefix = "zulu21.48.15-ca-jdk21.0.10-linux_x64",
+    )


### PR DESCRIPTION
* Remote JDK: Azul Zulu 21.34.19 CA -> 21.48.15 CA
* Embedded JDK used by Bazel server is purged from cache post-build.