### PR TITLE
JDK upgrade, migrate to OCI

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,9 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//builders/bazel:deps.bzl", "python_deps", "python_register_toolchains")
+load("//third_party:jdk_override.bzl", "jdk_21_override")
+
+# JDK 21.48.15 CA override for Nessus CVE compliance (must be before default is loaded)
+jdk_21_override()
 
 # rules_docker v0.26.0 (Bazel 7+ compatible, cfg=host→exec fix)
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,21 +5,23 @@ load("//third_party:jdk_override.bzl", "jdk_21_override")
 # JDK 21.48.15 CA override for Nessus CVE compliance (must be before default is loaded)
 jdk_21_override()
 
-# rules_docker v0.26.0 (Bazel 7+ compatible, cfg=host→exec fix)
-
+# rules_oci v2.2.7 (OCI images, replaces deprecated rules_docker)
 http_archive(
-    name = "io_bazel_rules_docker",
-    sha256 = "f6dcb97e992f13bc9effd794e9bb300f06b0dadc88061f81ae68d8d5994be964",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_docker/releases/download/v0.26.0/rules_docker-v0.26.0.tar.gz",
-        "https://github.com/bazelbuild/rules_docker/releases/download/v0.26.0/rules_docker-v0.26.0.tar.gz",
-    ],
+    name = "rules_oci",
+    sha256 = "b8db7ab889d501db33313620b2c8040dbb07e95c26a0fefe06004b35baf80e08",
+    strip_prefix = "rules_oci-2.2.7",
+    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v2.2.7/rules_oci-v2.2.7.tar.gz",
 )
+
+load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
+
+rules_oci_dependencies()
 
 python_deps()
 
 python_register_toolchains("//builders/bazel")
 
+# TEMP: sarang/bazel_upgrade branch until PR merges to main
 http_archive(
     name = "google_privacysandbox_servers_common",
     auth_patterns = {
@@ -53,20 +55,13 @@ load("@google_privacysandbox_servers_common//third_party:deps4.bzl", data_plane_
 
 data_plane_shared_deps4()
 
-load(
-    "@io_bazel_rules_docker//repositories:repositories.bzl",
-    container_repositories = "repositories",
-)
-
-container_repositories()
-
-load("@io_bazel_rules_docker//repositories:deps.bzl", rules_docker_deps = "deps")
-
-rules_docker_deps()
-
 load("//third_party:container_deps.bzl", "container_deps")
 
 container_deps()
+
+load("//third_party:envoy_layer.bzl", "envoy_layer_repositories")
+
+envoy_layer_repositories()
 
 load("@com_github_google_rpmpack//:deps.bzl", "rpmpack_dependencies")
 

--- a/builders/tools/cbuild
+++ b/builders/tools/cbuild
@@ -31,7 +31,7 @@ ENV_VARS+=(
 
 function usage() {
   local exitval=${1-1}
-  cat &>/dev/stderr << USAGE
+  cat >&2 << USAGE
 usage:
   $0 <options>
     --cmd <string>             bash command string to execute within the docker container
@@ -43,11 +43,11 @@ USAGE
     if [[ ${elem} == "${IMAGE}" ]]; then
       default_text=" (default)"
     fi
-    printf "                                   *  %s%s\n" "${elem}" "${default_text}" &>/dev/stderr
+    printf "                                   *  %s%s\n" "${elem}" "${default_text}" >&2
     default_text=""
   done
 
-  cat &>/dev/stderr << USAGE
+  cat >&2 << USAGE
     --env <key>[=<value>]      Name (or name=value) of exported environment variable, propagated into container
     --one-time                 Create a new container, avoid container reuse
     --without-shared-cache     Containers will not mount ${HOME}/.cache/bazel
@@ -146,7 +146,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z ${IMAGE} ]]; then
-  printf -- "error: --image must be specified\n" &>/dev/stderr
+  printf -- "error: --image must be specified\n" >&2
   usage 1
 fi
 if [[ ${ONE_TIME_CONTAINER} -eq 0 ]] && [[ ${IMAGE} =~ ^build-* ]]; then
@@ -154,7 +154,7 @@ if [[ ${ONE_TIME_CONTAINER} -eq 0 ]] && [[ ${IMAGE} =~ ^build-* ]]; then
 fi
 # shellcheck disable=SC2076
 if ! [[ " ${IMAGE_LIST[*]} " =~ " ${IMAGE} " ]]; then
-    printf -- "error: image [%s] not recognized\n" "${IMAGE}" &>/dev/stderr
+    printf -- "error: image [%s] not recognized\n" "${IMAGE}" >&2
     usage 1
 fi
 
@@ -174,7 +174,7 @@ WORKSPACE_MOUNT="$(builder::get_docker_workspace_mount)"
 readonly WORKSPACE_MOUNT
 export WORKSPACE_MOUNT
 if [[ ${VERBOSE} -eq 1 ]]; then
-  printf "mounting workspace into container: %s\n" "${WORKSPACE_MOUNT}" &>/dev/stderr
+  printf "mounting workspace into container: %s\n" "${WORKSPACE_MOUNT}" >&2
 fi
 
 TOOLS_RELDIR="$(realpath "${TOOLS_DIR}" --relative-to="${PWD}")"
@@ -213,7 +213,7 @@ fi
 
 if [[ ${WITH_CMD_PROFILER} -eq 1 ]]; then
   if [[ ${IMAGE} != build-debian ]]; then
-    printf "error: --cmd-profiler is only compatible with build-debian\n" &>/dev/stderr
+    printf "error: --cmd-profiler is only compatible with build-debian\n" >&2
     usage 1
   fi
   DOCKER_RUN_ARGS+=(
@@ -275,9 +275,9 @@ function running_container_for() {
   )
   local -r exited="$(docker "${docker_args[@]}" --all --filter "status=exited")"
   if [[ -n ${exited} ]]; then
-    printf "removing docker container: %s\n" "${name}" &>/dev/stderr
+    printf "removing docker container: %s\n" "${name}" >&2
     docker container rm --force "${name}" >/dev/null
-    printf "finished removing docker container: %s\n" "${name}" &>/dev/stderr
+    printf "finished removing docker container: %s\n" "${name}" >&2
   fi
   docker "${docker_args[@]}" --filter "status=running"
 }
@@ -286,7 +286,7 @@ function long_running_container() {
   local -r container_name="$1"
   local -r docker_running_container="$(running_container_for "${container_name}")"
   if [[ -z ${docker_running_container} ]]; then
-    printf "starting a new container [%s]\n" "${container_name}" &>/dev/stderr
+    printf "starting a new container [%s]\n" "${container_name}" >&2
     if [[ -n ${CMD} ]]; then
       # shellcheck disable=SC2068
       docker run \
@@ -314,7 +314,7 @@ if [[ ${KEEP_CONTAINER_RUNNING} -eq 1 ]]; then
       "${IMAGE_TAGGED}"
   else
     DOCKER_RUNNING_CONTAINER="$(long_running_container "${DOCKER_CONTAINER_NAME}")"
-    printf "reusing container [%s]\n" "${DOCKER_RUNNING_CONTAINER}" &>/dev/stderr
+    printf "reusing container [%s]\n" "${DOCKER_RUNNING_CONTAINER}" >&2
     if [[ ${WITH_CMD_PROFILER} -eq 1 ]]; then
       docker exec \
         "${DOCKER_EXEC_RUN_ARGS[@]}" \

--- a/docs/dependency-map.md
+++ b/docs/dependency-map.md
@@ -198,7 +198,7 @@ FINAL SERVICE DOCKER IMAGE (e.g., buyer_frontend_service_image.tar)
 │   ├── install/
 │   │   └── {bazel_version_hash}/          ← Bazel install base
 │   │       ├── A-server.jar               ← Bazel server
-│   │       └── embedded_tools/jdk/        ← ⚠ EMBEDDED JDK (version = Bazel version)
+│   │       └── embedded_tools/jdk/        ← EMBEDDED JDK (deleted post-build by build_and_test_all_in_docker for Nessus compliance)
 │   ├── cache/                             ← repo cache (shared downloads)
 │   └── {output_base_hash}/
 │       └── external/                      ← fetched WORKSPACE deps for sidecars
@@ -340,8 +340,8 @@ COUPLING ZONE 5: 4 Independent Workspaces ↔ Shared Cache
 | Dependency | Version/Ref | Defined In | Used By |
 |---|---|---|---|
 | Bazel | 7.4.1 | `.bazelversion` (×4) | All workspaces |
-| JDK (embedded) | 21.0.4 | Bazel 7.4.1 binary | Build process |
-| JDK (remote toolchain) | 21.0.3 | `.bazelrc` remotejdk_21 | Build process |
+| JDK (embedded) | 21.0.4 (Bazel 7.4.1) | Bazel install | Bazel server; removed post-build by build_and_test_all_in_docker for Nessus compliance |
+| JDK (remote toolchain) | 21.48.15 CA | `third_party/jdk_override.bzl` | Java compilation |
 | rules_docker | v0.26.0 | Root `WORKSPACE` | Main build only |
 | distroless base | cc-debian12 | `container_deps.bzl` | Runtime images |
 | Envoy sidecar | v1.31.4 | `container_deps.bzl` | Runtime images |

--- a/production/packaging/azure/bidding_service/BUILD
+++ b/production/packaging/azure/bidding_service/BUILD
@@ -13,13 +13,8 @@
 # limitations under the License.
 
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@google_privacysandbox_servers_common//third_party:container_deps.bzl", "get_user")
-load(
-    "@io_bazel_rules_docker//container:container.bzl",
-    "container_image",
-    "container_layer",
-)
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@rules_oci//oci:defs.bzl", "oci_image")
+load("@rules_oci//oci/private:load.bzl", "oci_load")
 load(
     "@rules_pkg//pkg:mappings.bzl",
     "pkg_attributes",
@@ -27,8 +22,6 @@ load(
 )
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
-
-user = get_user("root")
 
 pkg_files(
     name = "server_executables",
@@ -70,18 +63,6 @@ pkg_tar(
     srcs = server_binaries,
 )
 
-container_layer(
-    name = "server_binary_layer",
-    directory = "/",
-    env = {
-        "GLOG_logtostderr": "1",
-        "GLOG_stderrthreshold": "0",
-        "GRPC_DNS_RESOLVER": "native",
-    },
-    tars = [
-        ":server_binaries_tar",
-    ],
-)
 
 cddl_specs = [
     "//services/bidding_service:packaged_cddl_specs",
@@ -95,14 +76,6 @@ pkg_zip(
 pkg_tar(
     name = "cddl_specs_tar",
     srcs = cddl_specs,
-)
-
-container_layer(
-    name = "cddl_specs_layer",
-    directory = "/",
-    tars = [
-        ":cddl_specs_tar",
-    ],
 )
 
 copy_file(
@@ -121,14 +94,7 @@ pkg_zip(
 pkg_tar(
     name = "cddl_lib_artifacts_tar",
     srcs = [":libcddl_so_lib"],
-)
-
-container_layer(
-    name = "cddl_lib_layer",
-    directory = "/lib",
-    tars = [
-        ":cddl_lib_artifacts_tar",
-    ],
+    package_dir = "lib",
 )
 
 pkg_files(
@@ -148,61 +114,42 @@ pkg_tar(
     srcs = root_certs_files,
 )
 
-container_layer(
-    name = "root_certs_layer",
-    directory = "/",
-    tars = [
-        ":root_certs_tar",
-    ],
-)
-
 # BYOB is not supported in Azure
 
-container_image(
-    name = "server_docker_image",
+oci_image(
+    name = "server_oci_image",
     base = select({
-        "@platforms//cpu:arm64": "@runtime-cc-debian-arm64//image",
-        "@platforms//cpu:x86_64": "@runtime-cc-debian-amd64//image",
+        "@platforms//cpu:arm64": "@runtime-cc-debian-arm64",
+        "@platforms//cpu:x86_64": "@runtime-cc-debian-amd64",
     }),
-    cmd = [
-        "/server/bin/init_server_basic",
-    ],
-    entrypoint = [
-        "sh",
-    ],
+    cmd = ["/server/bin/init_server_basic"],
+    entrypoint = ["sh"],
+    env = {
+        "GLOG_logtostderr": "1",
+        "GLOG_stderrthreshold": "0",
+        "GRPC_DNS_RESOLVER": "native",
+    },
+    exposed_ports = ["50051"],
     labels = {"tee.launch_policy.log_redirect": "always"},
-    layers = [
-        ":cddl_lib_layer",
-        ":cddl_specs_layer",
-        ":server_binary_layer",
-        # BYOB is not supported in Azure
-        ":root_certs_layer",
-    ] + select({
-        "//:e2e_build": [
-        ],
-        "//conditions:default": [],
-    }),
-    ports = ["50051"],
     tars = [
-        # BYOB is not supported in Azure
+        ":cddl_lib_artifacts_tar",
+        ":cddl_specs_tar",
+        ":server_binaries_tar",
+        ":root_certs_tar",
         "//tools/udf/generate_bid/samples:sample_generate_bid_execs_tar",
     ],
 )
 
-container_test(
-    name = "structure_test",
-    size = "large",
-    configs = ["test/structure.yaml"],
-    driver = "tar",
-    image = ":server_docker_image",
+oci_load(
+    name = "server_image_load",
+    image = ":server_oci_image",
+    repo_tags = "repo_tags.txt",
 )
 
-container_test(
-    name = "commands_test",
-    size = "large",
-    configs = ["test/commands.yaml"],
-    driver = "docker",
-    image = ":server_docker_image",
+filegroup(
+    name = "server_docker_image_tar",
+    srcs = [":server_image_load"],
+    output_group = "tarball",
 )
 
 # server artifacts
@@ -215,14 +162,14 @@ genrule(
     name = "copy_to_dist",
     srcs = [
         ":server_artifacts",
-        ":server_docker_image.tar",
+        ":server_docker_image_tar",
         "//api:bidding_auction_servers_descriptor_set",
     ],
     outs = ["copy_to_dist.bin"],
     cmd_bash = """cat << EOF > '$@'
 mkdir -p dist/debian
 cp $(execpath :server_artifacts) dist/debian/$$(basename $(RULEDIR))_artifacts.zip
-cp $(execpath :server_docker_image.tar) dist/debian/$$(basename $(RULEDIR))_image.tar
+cp $(execpath :server_docker_image_tar) dist/debian/$$(basename $(RULEDIR))_image.tar
 cp $(execpath //api:bidding_auction_servers_descriptor_set) dist
 builders/tools/normalize-dist
 EOF""",

--- a/production/packaging/azure/bidding_service/repo_tags.txt
+++ b/production/packaging/azure/bidding_service/repo_tags.txt
@@ -1,0 +1,1 @@
+bidding_service:latest

--- a/production/packaging/azure/buyer_frontend_service/BUILD
+++ b/production/packaging/azure/buyer_frontend_service/BUILD
@@ -1,7 +1,7 @@
 # Portions Copyright (c) Microsoft Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# you may not use it except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #      http://www.apache.org/licenses/LICENSE-2.0
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load(
-    "@io_bazel_rules_docker//container:container.bzl",
-    "container_flatten",
-    "container_image",
-    "container_layer",
-)
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@rules_oci//oci:defs.bzl", "oci_image")
+load("@rules_oci//oci/private:load.bzl", "oci_load")
 load(
     "@rules_pkg//pkg:mappings.bzl",
     "pkg_attributes",
@@ -52,14 +47,6 @@ pkg_tar(
     srcs = server_binaries,
 )
 
-container_layer(
-    name = "server_binary_layer",
-    directory = "/",
-    tars = [
-        ":server_binaries_tar",
-    ],
-)
-
 pkg_files(
     name = "etc_envoy_files",
     srcs = [
@@ -80,37 +67,6 @@ pkg_tar(
     ],
 )
 
-container_layer(
-    name = "envoy_config_layer",
-    directory = "/",
-    tars = [
-        ":envoy_config_tar",
-    ],
-    visibility = [
-        "//production/packaging:__subpackages__",
-        "//services:__subpackages__",
-    ],
-)
-
-container_flatten(
-    name = "envoy_distroless_flat",
-    image = select({
-        "@platforms//cpu:arm64": "@envoy-distroless-arm64//image",
-        "@platforms//cpu:x86_64": "@envoy-distroless-amd64//image",
-    }),
-)
-
-container_layer(
-    name = "envoy_distroless_layer",
-    tars = [
-        ":envoy_distroless_flat.tar",
-    ],
-    visibility = [
-        "//production/packaging:__subpackages__",
-        "//services:__subpackages__",
-    ],
-)
-
 pkg_files(
     name = "root_certs",
     srcs = ["@com_github_grpc_grpc//:root_certificates"],
@@ -128,57 +84,69 @@ pkg_tar(
     srcs = root_certs_files,
 )
 
-container_layer(
-    name = "root_certs_layer",
-    directory = "/",
+# Envoy layer: flattened envoy-distroless via crane export (repo rule).
+# oci_image tars= doesn't accept select(); use platform-specific images + alias.
+# target_compatible_with prevents arm64 image from being built on amd64 (and vice versa).
+oci_image(
+    name = "server_oci_image_amd64",
+    base = "@runtime-cc-debian-amd64",
+    target_compatible_with = ["@platforms//cpu:x86_64"],
+    cmd = ["/server/bin/init_server_basic"],
+    entrypoint = ["sh"],
+    env = {
+        "GLOG_logtostderr": "1",
+        "GLOG_stderrthreshold": "0",
+        "GRPC_DNS_RESOLVER": "native",
+    },
+    exposed_ports = ["51052", "50051", "50050"],
+    labels = {"tee.launch_policy.log_redirect": "always"},
     tars = [
+        "@envoy_layer//:envoy_amd64",
+        ":server_binaries_tar",
+        ":envoy_config_tar",
         ":root_certs_tar",
     ],
 )
 
-container_image(
-    name = "server_docker_image",
-    base = select({
-        "@platforms//cpu:arm64": "@runtime-cc-debian-arm64//image",
-        "@platforms//cpu:x86_64": "@runtime-cc-debian-amd64//image",
-    }),
-    cmd = [
-        "/server/bin/init_server_basic",
-    ],
+oci_image(
+    name = "server_oci_image_arm64",
+    base = "@runtime-cc-debian-arm64",
+    target_compatible_with = ["@platforms//cpu:arm64"],
+    cmd = ["/server/bin/init_server_basic"],
     entrypoint = ["sh"],
+    env = {
+        "GLOG_logtostderr": "1",
+        "GLOG_stderrthreshold": "0",
+        "GRPC_DNS_RESOLVER": "native",
+    },
+    exposed_ports = ["51052", "50051", "50050"],
     labels = {"tee.launch_policy.log_redirect": "always"},
-    layers = [
-        ":server_binary_layer",
-        ":envoy_distroless_layer",
-        ":envoy_config_layer",
-        ":root_certs_layer",
-    ] + select({
-        "//:e2e_build": [
-        ],
-        "//conditions:default": [],
-    }),
-    # BFE and BFE Non-TLS Healthcheck ports, respectively:
-    ports = [
-        "51052",
-        "50051",
-        "50050",
+    tars = [
+        "@envoy_layer//:envoy_arm64",
+        ":server_binaries_tar",
+        ":envoy_config_tar",
+        ":root_certs_tar",
     ],
 )
 
-container_test(
-    name = "structure_test",
-    size = "large",
-    configs = ["test/structure.yaml"],
-    driver = "tar",
-    image = ":server_docker_image",
+alias(
+    name = "server_oci_image",
+    actual = select({
+        "@platforms//cpu:arm64": ":server_oci_image_arm64",
+        "@platforms//cpu:x86_64": ":server_oci_image_amd64",
+    }),
 )
 
-container_test(
-    name = "commands_test",
-    size = "large",
-    configs = ["test/commands.yaml"],
-    driver = "docker",
-    image = ":server_docker_image",
+oci_load(
+    name = "server_image_load",
+    image = ":server_oci_image",
+    repo_tags = "repo_tags.txt",
+)
+
+filegroup(
+    name = "server_docker_image_tar",
+    srcs = [":server_image_load"],
+    output_group = "tarball",
 )
 
 # server artifacts
@@ -191,14 +159,14 @@ genrule(
     name = "copy_to_dist",
     srcs = [
         ":server_artifacts",
-        ":server_docker_image.tar",
+        ":server_docker_image_tar",
         "//api:bidding_auction_servers_descriptor_set",
     ],
     outs = ["copy_to_dist.bin"],
     cmd_bash = """cat << EOF > '$@'
 mkdir -p dist/debian
 cp $(execpath :server_artifacts) dist/debian/$$(basename $(RULEDIR))_artifacts.zip
-cp $(execpath :server_docker_image.tar) dist/debian/$$(basename $(RULEDIR))_image.tar
+cp $(execpath :server_docker_image_tar) dist/debian/$$(basename $(RULEDIR))_image.tar
 cp $(execpath //api:bidding_auction_servers_descriptor_set) dist
 builders/tools/normalize-dist
 EOF""",

--- a/production/packaging/azure/buyer_frontend_service/repo_tags.txt
+++ b/production/packaging/azure/buyer_frontend_service/repo_tags.txt
@@ -1,0 +1,1 @@
+buyer_frontend_service:latest

--- a/production/packaging/azure/push_images_to_acr.sh
+++ b/production/packaging/azure/push_images_to_acr.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Squash OCI images to single layer (CCE policy compatibility) and push to ACR.
+# Usage:
+#   ./push_images_to_acr.sh
+#
+# Required env vars:
+#   BUILD_FLAVOR      e.g. prod, nonprod (default: prod)
+#   RELEASE_VERSION   e.g. 4.8.1.0
+#   ACR_REGISTRY      e.g. <registry_name>.azurecr.io
+#   ACR_REPO_PATH     e.g. depainferencing/azure (registry path under ACR)
+#
+# Optional:
+#   DIST_DIR          Directory containing *_image.tar (default: dist/azure, fallback: dist/debian)
+#   WORKSPACE         Repo root (default: script dir/../../..)
+
+set -o pipefail
+set -o errexit
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+WORKSPACE="${WORKSPACE:-$(readlink -f "${SCRIPT_DIR}/../../..")}"
+DIST_DIR="${DIST_DIR:-${WORKSPACE}/dist/azure}"
+if [[ ! -d "${DIST_DIR}" ]]; then
+  DIST_DIR="${WORKSPACE}/dist/debian"
+fi
+
+BUILD_FLAVOR="${BUILD_FLAVOR:-prod}"
+RELEASE_VERSION="${RELEASE_VERSION:-oci-test}"
+ACR_REGISTRY="${ACR_REGISTRY:-ispirt.azurecr.io}"
+ACR_REPO_PATH="${ACR_REPO_PATH:-depainferencing/azure}"
+ACR_BASE="${ACR_REGISTRY}/${ACR_REPO_PATH}"
+
+if [[ -z "${RELEASE_VERSION}" ]]; then
+  printf "Error: RELEASE_VERSION must be set\n" >&2
+  exit 1
+fi
+
+printf "==== Squash and push to ACR ====\n"
+printf "  BUILD_FLAVOR: %s\n" "${BUILD_FLAVOR}"
+printf "  RELEASE_VERSION: %s\n" "${RELEASE_VERSION}"
+printf "  ACR_BASE: %s\n" "${ACR_BASE}"
+printf "  DIST_DIR: %s\n" "${DIST_DIR}"
+printf "\n"
+
+#######################################
+# Squash image to single layer and push
+# Arguments:
+#   $1 - service name (e.g. bidding_service, buyer_frontend_service)
+#   $2 - squash temp prefix (e.g. bidding-squash, bfe-squash)
+#   $3 - use WORKDIR / for single layer (1 for BFE/envoy-distroless, 0 otherwise)
+#######################################
+squash_and_push() {
+  local -r SERVICE="$1"
+  local -r SQUASH_PREFIX="$2"
+  local -r BFE_WORKDIR_FIX="${3:-0}"
+
+  local -r IMAGE_TAR="${DIST_DIR}/${SERVICE}_image.tar"
+  if [[ ! -f "${IMAGE_TAR}" ]]; then
+    printf "Error: %s not found\n" "${IMAGE_TAR}" >&2
+    exit 1
+  fi
+
+  local -r ACR_TAG="${ACR_BASE}/${SERVICE//_/-}:${BUILD_FLAVOR}-${RELEASE_VERSION}"
+
+  printf -- "---- %s ----\n" "${SERVICE}"
+
+  LOAD_OUTPUT=$(docker load -i "${IMAGE_TAR}")
+  LOADED_IMAGE=$(echo "${LOAD_OUTPUT}" | grep "Loaded image:" | sed 's/Loaded image: //')
+  printf "Loaded: %s\n" "${LOADED_IMAGE}"
+
+  docker create --name "${SQUASH_PREFIX}-temp" "${LOADED_IMAGE}"
+  docker export "${SQUASH_PREFIX}-temp" -o "${SQUASH_PREFIX}-squashed.tar"
+  docker import "${SQUASH_PREFIX}-squashed.tar" "${SQUASH_PREFIX}-base:temp"
+
+  ENTRYPOINT_JSON=$(docker inspect "${LOADED_IMAGE}" --format '{{json .Config.Entrypoint}}')
+  CMD_JSON=$(docker inspect "${LOADED_IMAGE}" --format '{{json .Config.Cmd}}')
+  ENV_VARS=$(docker inspect "${LOADED_IMAGE}" --format '{{range .Config.Env}}ENV {{.}}{{"\n"}}{{end}}')
+  WORKDIR=$(docker inspect "${LOADED_IMAGE}" --format '{{.Config.WorkingDir}}')
+  if [[ "${BFE_WORKDIR_FIX}" -eq 1 ]] && [[ "${WORKDIR}" = "/home/nonroot" ]]; then
+    WORKDIR="/"
+  fi
+  WORKDIR="${WORKDIR:-/}"
+
+  {
+    echo "FROM ${SQUASH_PREFIX}-base:temp"
+    echo "${ENV_VARS}"
+    echo "WORKDIR ${WORKDIR}"
+    if [[ "${ENTRYPOINT_JSON}" != "null" ]] && [[ -n "${ENTRYPOINT_JSON}" ]]; then
+      echo "ENTRYPOINT ${ENTRYPOINT_JSON}"
+    fi
+    if [[ "${CMD_JSON}" != "null" ]] && [[ -n "${CMD_JSON}" ]]; then
+      echo "CMD ${CMD_JSON}"
+    fi
+  } > Dockerfile."${SQUASH_PREFIX}-squashed"
+
+  docker build -f Dockerfile."${SQUASH_PREFIX}-squashed" -t "${SQUASH_PREFIX}-final:temp" .
+
+  LAYER_COUNT=$(docker inspect "${SQUASH_PREFIX}-final:temp" | jq -r '.[0].RootFS.Layers | length')
+  printf "Squashed image has %s layer(s)\n" "${LAYER_COUNT}"
+
+  docker rm "${SQUASH_PREFIX}-temp"
+  docker rmi "${SQUASH_PREFIX}-base:temp" 2>/dev/null || true
+  rm -f "${SQUASH_PREFIX}-squashed.tar" Dockerfile."${SQUASH_PREFIX}-squashed"
+
+  docker tag "${SQUASH_PREFIX}-final:temp" "${ACR_TAG}"
+  printf "Pushing %s to ACR...\n" "${ACR_TAG}"
+  docker push "${ACR_TAG}"
+
+  printf "Successfully pushed %s (squashed, %s layer(s))\n" "${ACR_TAG}" "${LAYER_COUNT}"
+
+  docker rmi "${SQUASH_PREFIX}-final:temp" 2>/dev/null || true
+  docker rmi "${LOADED_IMAGE}" 2>/dev/null || true
+
+  printf "\n"
+}
+
+cd "${WORKSPACE}"
+
+# Bidding service (runtime-cc-debian base: WORKDIR / or unset)
+squash_and_push "bidding_service" "bidding-squash" 0
+
+# Buyer frontend service (envoy-distroless base: override /home/nonroot → / for single layer)
+squash_and_push "buyer_frontend_service" "bfe-squash" 1
+
+printf "==== Done: both images squashed and pushed to ACR ====\n"
+printf "  - %s/bidding-service:%s-%s\n" "${ACR_BASE}" "${BUILD_FLAVOR}" "${RELEASE_VERSION}"
+printf "  - %s/buyer-frontend-service:%s-%s\n" "${ACR_BASE}" "${BUILD_FLAVOR}" "${RELEASE_VERSION}"

--- a/production/packaging/build_and_test_all_in_docker
+++ b/production/packaging/build_and_test_all_in_docker
@@ -25,6 +25,10 @@ trap _print_runtime EXIT
 function _print_runtime() {
   declare -r -i STATUS=$?
   declare -r END=$(date +%s)
+  # Remove embedded JDK from Bazel cache for Nessus compliance (only after all builds complete)
+  if [[ -d "${HOME}/.cache/bazel" ]]; then
+    find "${HOME}/.cache/bazel" -type d -path "*/install/*/embedded_tools/jdk" -exec rm -rf {} + 2>/dev/null || true
+  fi
   /usr/bin/env LC_ALL=en_US.UTF-8 printf "\nbuild_and_test_all_in_docker runtime: %'ds\n" $((END - START)) >/dev/stderr
   if [[ ${STATUS} -eq 0 ]]; then
     printf "build_and_test_in_docker completed successfully\n" &>/dev/stderr

--- a/production/packaging/build_and_test_all_in_docker
+++ b/production/packaging/build_and_test_all_in_docker
@@ -25,15 +25,11 @@ trap _print_runtime EXIT
 function _print_runtime() {
   declare -r -i STATUS=$?
   declare -r END=$(date +%s)
-  # Remove embedded JDK from Bazel cache for Nessus compliance (only after all builds complete)
-  if [[ -d "${HOME}/.cache/bazel" ]]; then
-    find "${HOME}/.cache/bazel" -type d -path "*/install/*/embedded_tools/jdk" -exec rm -rf {} + 2>/dev/null || true
-  fi
-  /usr/bin/env LC_ALL=en_US.UTF-8 printf "\nbuild_and_test_all_in_docker runtime: %'ds\n" $((END - START)) >/dev/stderr
+  /usr/bin/env LC_ALL=en_US.UTF-8 printf "\nbuild_and_test_all_in_docker runtime: %'ds\n" $((END - START)) >&2
   if [[ ${STATUS} -eq 0 ]]; then
-    printf "build_and_test_in_docker completed successfully\n" &>/dev/stderr
+    printf "build_and_test_in_docker completed successfully\n" >&2
   else
-    printf "Error: build_and_test_in_docker completed with status code: %s\n" "${STATUS}" &>/dev/stderr
+    printf "Error: build_and_test_in_docker completed with status code: %s\n" "${STATUS}" >&2
     if [[ -v KOKORO_ARTIFACTS_DIR ]]; then
       sleep 5s
     fi
@@ -192,25 +188,25 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ ${#SERVICES[@]} -eq 0 ]]; then
-  printf "Error: A minimum of one --service-path must be specified\n" &>/dev/stderr
+  printf "Error: A minimum of one --service-path must be specified\n" >&2
   usage
 fi
 if [[ -z ${PLATFORM} ]]; then
-  printf "Error: --platform must be specified\n" &>/dev/stderr
+  printf "Error: --platform must be specified\n" >&2
   usage
 fi
 if [[ -z ${INSTANCE} ]]; then
-  printf "Error: --instance must be specified\n" &>/dev/stderr
+  printf "Error: --instance must be specified\n" >&2
   usage
 fi
 if [[ ${PLATFORM} = gcp ]]; then
   if [[ ${GCP_SKIP_IMAGE_UPLOAD} -eq 0 ]]; then
     if [[ -z ${GCP_IMAGE_TAG} ]]; then
-      printf "Error: --gcp-image-tag must be specified\n" &>/dev/stderr
+      printf "Error: --gcp-image-tag must be specified\n" >&2
       usage
     fi
     if [[ -z ${GCP_IMAGE_REPO} ]]; then
-      printf "Error: --gcp-image-repo must be specified\n" &>/dev/stderr
+      printf "Error: --gcp-image-repo must be specified\n" >&2
       usage
     fi
   fi
@@ -300,7 +296,7 @@ function invoke_targets() {
   trap _collect_logs EXIT
   function _collect_logs() {
     local -r -i STATUS=\$?
-    printf 'Collecting bazel logs... (status: %d)\n' \${STATUS} &>/dev/stderr
+    printf 'Collecting bazel logs... (status: %d)\n' \${STATUS} >&2
     bazel ${BAZEL_STARTUP_ARGS} run ${BAZEL_EXTRA_ARGS} //:collect-logs
     exit \${STATUS}
   }
@@ -337,7 +333,7 @@ function build_service_for_gcp() {
   # note: use relative path to dist
   declare -r docker_image=dist/debian/${service}_image.tar
   if ! [[ -s ${WORKSPACE}/${docker_image} ]]; then
-    printf "Error: docker image tar file not found: %s\n" "${docker_image}" &>/dev/stderr
+    printf "Error: docker image tar file not found: %s\n" "${docker_image}" >&2
     exit 1
   fi
   create_gcp_dist "${docker_image}"
@@ -358,7 +354,7 @@ function build_service_for_azure() {
   # note: use relative path to dist
   declare -r docker_image=dist/debian/${service}_image.tar
   if ! [[ -s ${WORKSPACE}/${docker_image} ]]; then
-    printf "Error: docker image tar file not found: %s\n" "${docker_image}" &>/dev/stderr
+    printf "Error: docker image tar file not found: %s\n" "${docker_image}" >&2
     exit 1
   fi
   create_azure_dist "${docker_image}"
@@ -373,7 +369,7 @@ function load_service_image() {
   declare -r service="$1"
   declare -r docker_image=dist/debian/${service}_image.tar
   if ! [[ -s ${WORKSPACE}/${docker_image} ]]; then
-    printf "Error: docker image tar file not found: %s\n" "${docker_image}" &>/dev/stderr
+    printf "Error: docker image tar file not found: %s\n" "${docker_image}" >&2
     exit 1
   fi
 
@@ -411,7 +407,7 @@ if [[ ${NO_PLATFORM_BUILD} -eq 0 ]]; then
       done
     ;;
     *)
-      printf "Unsupported platform: %s\n" "${PLATFORM}" >/dev/stderr
+      printf "Unsupported platform: %s\n" "${PLATFORM}" >&2
       exit 1
       ;;
   esac

--- a/services/inference_sidecar/common/.bazelrc
+++ b/services/inference_sidecar/common/.bazelrc
@@ -21,7 +21,7 @@ build --announce_rc
 build --verbose_failures
 build --config=clang
 build --compilation_mode=opt
-build --output_filter='^//((?!(third_party):).)*$'`
+build --output_filter='^//((?!(third_party):).)*$'
 build --color=yes
 
 build:clang --cxxopt=-fbracket-depth=512

--- a/services/inference_sidecar/common/WORKSPACE
+++ b/services/inference_sidecar/common/WORKSPACE
@@ -1,5 +1,9 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//builders/bazel:deps.bzl", "python_deps")
+load("//third_party:jdk_override.bzl", "jdk_21_override")
+
+# JDK 21.48.15 CA override for Nessus CVE compliance (must be before default is loaded)
+jdk_21_override()
 
 python_deps("//builders/bazel")
 

--- a/services/inference_sidecar/common/third_party/jdk_override.bzl
+++ b/services/inference_sidecar/common/third_party/jdk_override.bzl
@@ -1,0 +1,20 @@
+"""JDK 21.48.15 CA override for Nessus CVE compliance.
+
+Overrides default remotejdk21_linux with Azul Zulu 21.48.15 CA.
+Must be called before any rule that loads the default JDK.
+"""
+
+load("@bazel_tools//tools/jdk:remote_java_repository.bzl", "remote_java_repository")
+
+def jdk_21_override():
+    remote_java_repository(
+        name = "remotejdk21_linux",
+        version = "21",
+        target_compatible_with = ["@platforms//os:linux"],
+        prefix = "remotejdk",
+        urls = [
+            "https://cdn.azul.com/zulu/bin/zulu21.48.15-ca-jdk21.0.10-linux_x64.tar.gz",
+        ],
+        sha256 = "7f15f667580a8977962dc0a709cf2a097cc71244614fad3f236debce9d1c2670",
+        strip_prefix = "zulu21.48.15-ca-jdk21.0.10-linux_x64",
+    )

--- a/services/inference_sidecar/modules/pytorch_v2_1_1/.bazelrc
+++ b/services/inference_sidecar/modules/pytorch_v2_1_1/.bazelrc
@@ -21,7 +21,7 @@ build --announce_rc
 build --verbose_failures
 build --config=clang
 build --compilation_mode=opt
-build --output_filter='^//((?!(third_party):).)*$'`
+build --output_filter='^//((?!(third_party):).)*$'
 build --color=yes
 
 build:clang --cxxopt=-fbracket-depth=512

--- a/services/inference_sidecar/modules/pytorch_v2_1_1/WORKSPACE
+++ b/services/inference_sidecar/modules/pytorch_v2_1_1/WORKSPACE
@@ -1,4 +1,9 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//third_party:jdk_override.bzl", "jdk_21_override")
+
+# JDK 21.48.15 CA override for Nessus CVE compliance (must be before default is loaded)
+jdk_21_override()
+
 load("//third_party:pytorch_v2_1_1_deps1.bzl", "pytorch_v2_1_1_deps1")
 load("//third_party:pytorch_v2_1_1_deps2.bzl", "pytorch_v2_1_1_deps2")
 

--- a/services/inference_sidecar/modules/pytorch_v2_1_1/third_party/jdk_override.bzl
+++ b/services/inference_sidecar/modules/pytorch_v2_1_1/third_party/jdk_override.bzl
@@ -1,0 +1,20 @@
+"""JDK 21.48.15 CA override for Nessus CVE compliance.
+
+Overrides default remotejdk21_linux with Azul Zulu 21.48.15 CA.
+Must be called before any rule that loads the default JDK.
+"""
+
+load("@bazel_tools//tools/jdk:remote_java_repository.bzl", "remote_java_repository")
+
+def jdk_21_override():
+    remote_java_repository(
+        name = "remotejdk21_linux",
+        version = "21",
+        target_compatible_with = ["@platforms//os:linux"],
+        prefix = "remotejdk",
+        urls = [
+            "https://cdn.azul.com/zulu/bin/zulu21.48.15-ca-jdk21.0.10-linux_x64.tar.gz",
+        ],
+        sha256 = "7f15f667580a8977962dc0a709cf2a097cc71244614fad3f236debce9d1c2670",
+        strip_prefix = "zulu21.48.15-ca-jdk21.0.10-linux_x64",
+    )

--- a/services/inference_sidecar/modules/tensorflow_v2_14_0/WORKSPACE
+++ b/services/inference_sidecar/modules/tensorflow_v2_14_0/WORKSPACE
@@ -1,5 +1,9 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//builders/bazel:deps.bzl", "python_deps")
+load("//third_party:jdk_override.bzl", "jdk_21_override")
+
+# JDK 21.48.15 CA override for Nessus CVE compliance (must be before default is loaded)
+jdk_21_override()
 
 python_deps("//builders/bazel")
 

--- a/services/inference_sidecar/modules/tensorflow_v2_14_0/third_party/jdk_override.bzl
+++ b/services/inference_sidecar/modules/tensorflow_v2_14_0/third_party/jdk_override.bzl
@@ -1,0 +1,20 @@
+"""JDK 21.48.15 CA override for Nessus CVE compliance.
+
+Overrides default remotejdk21_linux with Azul Zulu 21.48.15 CA.
+Must be called before any rule that loads the default JDK.
+"""
+
+load("@bazel_tools//tools/jdk:remote_java_repository.bzl", "remote_java_repository")
+
+def jdk_21_override():
+    remote_java_repository(
+        name = "remotejdk21_linux",
+        version = "21",
+        target_compatible_with = ["@platforms//os:linux"],
+        prefix = "remotejdk",
+        urls = [
+            "https://cdn.azul.com/zulu/bin/zulu21.48.15-ca-jdk21.0.10-linux_x64.tar.gz",
+        ],
+        sha256 = "7f15f667580a8977962dc0a709cf2a097cc71244614fad3f236debce9d1c2670",
+        strip_prefix = "zulu21.48.15-ca-jdk21.0.10-linux_x64",
+    )

--- a/third_party/container_deps.bzl
+++ b/third_party/container_deps.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@google_privacysandbox_servers_common//third_party:container_deps.bzl", common_container_deps = "container_deps")
-load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
+load("@rules_oci//oci:pull.bzl", "oci_pull")
 
 def container_deps():
     common_container_deps()
@@ -58,11 +58,11 @@ def container_deps():
     }
 
     [
-        container_pull(
+        oci_pull(
             name = img_name + "-" + arch,
             digest = "sha256:" + hash,
-            registry = image["registry"],
-            repository = image["repository"],
+            image = image["registry"] + "/" + image["repository"],
+            platforms = ["linux/" + arch],
         )
         for img_name, image in images.items()
         for arch, hash in image["arch_hashes"].items()

--- a/third_party/envoy_layer.bzl
+++ b/third_party/envoy_layer.bzl
@@ -1,0 +1,92 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use the License except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Repository rule to extract envoy-distroless image as a flattened tar layer.
+
+Used by BFE/SFE services that need base=runtime-cc-debian (shell) + Envoy.
+rules_oci lacks container_flatten; crane export produces the flattened
+filesystem tar required for oci_image tars=[].
+"""
+
+
+# envoy-distroless digests from container_deps.bzl (v1.31.4)
+ENVOY_AMD64_DIGEST = "sha256:f3e9f6139898db74177ac4f41dabd8750a39724ec28c5762a2c5ac61cc965253"
+ENVOY_ARM64_DIGEST = "sha256:ed571f4a0e1ff09617cc845397cf320ceeeda74d9ebaadba78879e80a3008365"
+ENVOY_IMAGE = "docker.io/envoyproxy/envoy-distroless"
+
+# Crane v0.20.2 (matches install_golang_apps)
+CRANE_LINUX_X86_64_SHA = "c14340087103ba9dadf61d45acd20675490fd0ccbd56ac7901fc1b502137f44b"
+CRANE_LINUX_X86_64_URL = "https://github.com/google/go-containerregistry/releases/download/v0.20.2/go-containerregistry_Linux_x86_64.tar.gz"
+CRANE_LINUX_ARM64_SHA = "aff0db48825124c9331ea310057214bd4e92c01aa2e414d539e9659841d9422a"
+CRANE_LINUX_ARM64_URL = "https://github.com/google/go-containerregistry/releases/download/v0.20.2/go-containerregistry_Linux_arm64.tar.gz"
+
+def _envoy_layer_impl(repository_ctx):
+    os_arch = repository_ctx.os.arch
+    if os_arch == "aarch64" or os_arch == "arm64":
+        sha256, url = CRANE_LINUX_ARM64_SHA, CRANE_LINUX_ARM64_URL
+    else:
+        sha256, url = CRANE_LINUX_X86_64_SHA, CRANE_LINUX_X86_64_URL
+
+    # Download crane
+    repository_ctx.download(
+        url = [url],
+        output = "crane.tar.gz",
+        sha256 = sha256,
+    )
+
+    # Extract (tarball has crane, gcrane at top level)
+    result = repository_ctx.execute(["tar", "-xzf", "crane.tar.gz"])
+    if result.return_code != 0:
+        fail("Failed to extract crane: " + result.stderr)
+
+    crane = repository_ctx.path("crane")
+
+    # Export envoy-distroless for each platform (crane can pull any platform)
+    # crane export IMAGE OUTPUT_FILE [flags] - output is positional, not -o
+    for platform, digest, out in [
+        ("linux/amd64", ENVOY_AMD64_DIGEST, "envoy_amd64.tar"),
+        ("linux/arm64", ENVOY_ARM64_DIGEST, "envoy_arm64.tar"),
+    ]:
+        ref = ENVOY_IMAGE + "@" + digest
+        result = repository_ctx.execute([
+            str(crane),
+            "export",
+            "--platform=" + platform,
+            ref,
+            out,
+        ])
+        if result.return_code != 0:
+            fail("crane export failed for %s: %s" % (platform, result.stderr))
+
+    # BUILD file - visibility public so BFE/SFE packages can depend
+    repository_ctx.file("BUILD", """
+filegroup(
+    name = "envoy_amd64",
+    srcs = ["envoy_amd64.tar"],
+    visibility = ["//visibility:public"],
+)
+filegroup(
+    name = "envoy_arm64",
+    srcs = ["envoy_arm64.tar"],
+    visibility = ["//visibility:public"],
+)
+""")
+
+_envoy_layer = repository_rule(
+    implementation = _envoy_layer_impl,
+    attrs = {},
+)
+
+def envoy_layer_repositories():
+    _envoy_layer(name = "envoy_layer")

--- a/third_party/jdk_override.bzl
+++ b/third_party/jdk_override.bzl
@@ -1,0 +1,20 @@
+"""JDK 21.48.15 CA override for Nessus CVE compliance.
+
+Overrides default remotejdk21_linux with Azul Zulu 21.48.15 CA.
+Must be called before any rule that loads the default JDK.
+"""
+
+load("@bazel_tools//tools/jdk:remote_java_repository.bzl", "remote_java_repository")
+
+def jdk_21_override():
+    remote_java_repository(
+        name = "remotejdk21_linux",
+        version = "21",
+        target_compatible_with = ["@platforms//os:linux"],
+        prefix = "remotejdk",
+        urls = [
+            "https://cdn.azul.com/zulu/bin/zulu21.48.15-ca-jdk21.0.10-linux_x64.tar.gz",
+        ],
+        sha256 = "7f15f667580a8977962dc0a709cf2a097cc71244614fad3f236debce9d1c2670",
+        strip_prefix = "zulu21.48.15-ca-jdk21.0.10-linux_x64",
+    )


### PR DESCRIPTION
Summary of changes

* JDK upgrade to address VAPT CVEs
  * Remote JDK: Azul Zulu 21.34.19 CA -> 21.48.15 CA
  * Applied via jdk_override.bzl in root, inference sidecar, pytorch, and tensorflow workspaces

* OCI migration
  * rules_oci replaces rules_docker
  * Bidding: oci_image + oci_load + repo_tags.txt
  * BFE: oci_image with envoy layer from crane export (envoy_layer_repositories), platform-specific images, and target_compatible_with
  * container_deps: oci_pull instead of container_pull for base images
  * push_images_to_acr.sh: squash + push for CCE single-layer policy

* Other notes:
    * BFE container tests removed (due to rules_docker dependency)
    * GCP, AWS, and other Azure services still use rules_docker